### PR TITLE
fix(frontend): 修复配置不保存/错误误导/竞态/轮询/a11y 等 7 项缺陷（#13-#19）

### DIFF
--- a/frontend/src/__tests__/latestOnly.test.ts
+++ b/frontend/src/__tests__/latestOnly.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { LatestOnly } from '../lib/latestOnly'
+
+describe('LatestOnly', () => {
+  it('begin 返回递增序号', () => {
+    const gate = new LatestOnly()
+    expect(gate.begin()).toBe(1)
+    expect(gate.begin()).toBe(2)
+    expect(gate.begin()).toBe(3)
+  })
+
+  it('最新请求 isLatest 返回 true', () => {
+    const gate = new LatestOnly()
+    const seq = gate.begin()
+    expect(gate.isLatest(seq)).toBe(true)
+  })
+
+  it('先发请求被后发请求覆盖后 isLatest 返回 false', () => {
+    const gate = new LatestOnly()
+    const first = gate.begin()
+    const second = gate.begin()
+    expect(gate.isLatest(first)).toBe(false)
+    expect(gate.isLatest(second)).toBe(true)
+  })
+
+  it('独立实例互不影响', () => {
+    const a = new LatestOnly()
+    const b = new LatestOnly()
+    const sa = a.begin() // a.seq = 1
+    b.begin()
+    b.begin()            // b.seq = 2
+    expect(a.isLatest(sa)).toBe(true)  // a 只认自己实例的序号
+    expect(b.isLatest(sa)).toBe(false) // b 不认 a 的序号
+    expect(a.isLatest(2)).toBe(false)
+    expect(b.isLatest(2)).toBe(true)
+  })
+})

--- a/frontend/src/__tests__/taskStatus.test.ts
+++ b/frontend/src/__tests__/taskStatus.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { hasActiveTask } from '../lib/taskStatus'
+
+describe('hasActiveTask', () => {
+  it('全终态任务（done/error/cancelled 任意组合）返回 false', () => {
+    expect(hasActiveTask([{ status: 'done' }, { status: 'error' }, { status: 'cancelled' }])).toBe(false)
+    expect(hasActiveTask([{ status: 'done' }])).toBe(false)
+    expect(hasActiveTask([{ status: 'error' }])).toBe(false)
+    expect(hasActiveTask([{ status: 'cancelled' }])).toBe(false)
+    expect(hasActiveTask([{ status: 'done' }, { status: 'cancelled' }])).toBe(false)
+  })
+
+  it('含 downloading/paused/queued 时返回 true', () => {
+    expect(hasActiveTask([{ status: 'downloading' }])).toBe(true)
+    expect(hasActiveTask([{ status: 'paused' }])).toBe(true)
+    expect(hasActiveTask([{ status: 'queued' }])).toBe(true)
+    expect(hasActiveTask([{ status: 'downloading' }, { status: 'done' }])).toBe(true)
+    expect(hasActiveTask([{ status: 'queued' }, { status: 'error' }])).toBe(true)
+  })
+
+  it('空数组返回 false', () => {
+    expect(hasActiveTask([])).toBe(false)
+  })
+})

--- a/frontend/src/components/ModelSettings.vue
+++ b/frontend/src/components/ModelSettings.vue
@@ -1,10 +1,16 @@
 <template>
-  <div v-if="visible" class="modal-overlay" @click.self="close">
-    <div class="modal">
+  <div v-if="visible" class="modal-overlay" @click.self="close" @keydown.esc="close">
+    <div
+      class="modal"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="model-settings-title"
+      @keydown.tab="handleTab"
+    >
       <div class="modal-header">
-        <h2>模型设置</h2>
+        <h2 id="model-settings-title">模型设置</h2>
         <span class="modal-model">{{ modelName }}</span>
-        <button class="modal-close" @click="close">✕</button>
+        <button ref="closeBtn" class="modal-close" aria-label="关闭" @click="close">✕</button>
       </div>
 
       <div class="modal-body">
@@ -13,7 +19,7 @@
           <legend>性能</legend>
           <div class="param-row">
             <label>CPU 线程 (-t)</label>
-            <input v-model.number="cfg.threads" type="number" class="param-input param-num" placeholder="-1 (自动)" />
+            <input v-model.number="cfg.threads" type="number" min="-1" step="1" class="param-input param-num" placeholder="-1 (自动)" />
           </div>
           <div class="param-row">
             <label>GPU 层数 (-ngl)</label>
@@ -31,15 +37,15 @@
           </div>
           <div class="param-row">
             <label>上下文大小 (-c)</label>
-            <input v-model.number="cfg.ctxSize" type="number" class="param-input param-num" placeholder="4096" />
+            <input v-model.number="cfg.ctxSize" type="number" min="1" step="1" class="param-input param-num" placeholder="4096" />
           </div>
           <div class="param-row">
             <label>Batch 大小 (-b)</label>
-            <input v-model.number="cfg.batchSize" type="number" class="param-input param-num" placeholder="2048" />
+            <input v-model.number="cfg.batchSize" type="number" min="1" step="1" class="param-input param-num" placeholder="2048" />
           </div>
           <div class="param-row">
             <label>μBatch 大小 (-ub)</label>
-            <input v-model.number="cfg.ubatchSize" type="number" class="param-input param-num" placeholder="512" />
+            <input v-model.number="cfg.ubatchSize" type="number" min="1" step="1" class="param-input param-num" placeholder="512" />
           </div>
           <label class="param-check">
             <input type="checkbox" v-model="cfg.flashAttn" />
@@ -96,7 +102,7 @@
 </template>
 
 <script setup lang="ts">
-import { reactive, watch } from 'vue'
+import { reactive, ref, watch, nextTick } from 'vue'
 
 export interface ModelConfig {
   threads: number
@@ -140,9 +146,38 @@ const defaults: ModelConfig = {
 
 const cfg = reactive<ModelConfig>({ ...defaults, ...props.initialConfig })
 
+const closeBtn = ref<HTMLButtonElement | null>(null)
+
 watch(() => props.visible, (v) => {
-  if (v) Object.assign(cfg, defaults, props.initialConfig)
+  if (v) {
+    Object.assign(cfg, defaults, props.initialConfig)
+    // 弹窗打开后把焦点移入弹窗，配合下方 Tab 焦点陷阱（#17）
+    nextTick(() => closeBtn.value?.focus())
+  }
 })
+
+/** 焦点陷阱：Tab / Shift+Tab 在弹窗内可聚焦元素间循环，防止焦点逃逸到页面背景（#17） */
+function handleTab(e: KeyboardEvent) {
+  const modalEl = e.currentTarget as HTMLElement
+  const focusable = Array.from(
+    modalEl.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    )
+  ).filter(el => !el.hasAttribute('disabled'))
+  if (focusable.length === 0) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  const active = document.activeElement
+  if (e.shiftKey) {
+    if (active === first || !modalEl.contains(active)) {
+      e.preventDefault()
+      last.focus()
+    }
+  } else if (active === last) {
+    e.preventDefault()
+    first.focus()
+  }
+}
 
 function close() {
   emit('close')

--- a/frontend/src/lib/latestOnly.ts
+++ b/frontend/src/lib/latestOnly.ts
@@ -1,0 +1,8 @@
+/** 只保留最后一次发起的异步请求结果，丢弃过期响应（#15 竞态保护）。 */
+export class LatestOnly {
+  private seq = 0
+  /** 发起新请求，返回本次请求序号 */
+  begin(): number { return ++this.seq }
+  /** 该序号是否仍是最新请求（过期返回 false，调用方应丢弃结果） */
+  isLatest(seq: number): boolean { return seq === this.seq }
+}

--- a/frontend/src/lib/taskStatus.ts
+++ b/frontend/src/lib/taskStatus.ts
@@ -1,0 +1,4 @@
+/** 判断任务列表中是否仍有活跃任务（需要继续轮询）。终态：done/error/cancelled。 */
+export function hasActiveTask(tasks: { status: string }[]): boolean {
+  return tasks.some(t => t.status === 'downloading' || t.status === 'paused' || t.status === 'queued')
+}

--- a/frontend/src/views/Api.vue
+++ b/frontend/src/views/Api.vue
@@ -38,15 +38,15 @@
         </div>
         <div class="cfg-item">
           <label>Port</label>
-          <input v-model.number="cfg.port" type="number" class="cfg-input cfg-num" :disabled="serverRunning" />
+          <input v-model.number="cfg.port" type="number" min="1024" max="65535" step="1" class="cfg-input cfg-num" :disabled="serverRunning" />
         </div>
         <div class="cfg-item">
           <label>最大并发模型</label>
-          <input v-model.number="cfg.maxModels" type="number" class="cfg-input cfg-num" :disabled="serverRunning" />
+          <input v-model.number="cfg.maxModels" type="number" min="1" step="1" class="cfg-input cfg-num" :disabled="serverRunning" />
         </div>
         <div class="cfg-item">
           <label>Prompt 缓存 (MiB)</label>
-          <input v-model.number="cfg.cacheRam" type="number" class="cfg-input cfg-num" :disabled="serverRunning" placeholder="8192" />
+          <input v-model.number="cfg.cacheRam" type="number" min="0" step="1" class="cfg-input cfg-num" :disabled="serverRunning" placeholder="8192" />
         </div>
       </div>
     </section>
@@ -66,8 +66,8 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted, nextTick, watch } from 'vue'
-import { getServerConfig, getModels, getServerStatus, startServer, stopServer } from '../wails'
+import { ref, reactive, onMounted, onUnmounted, nextTick, watch } from 'vue'
+import { getServerConfig, getModels, getServerStatus, refreshModels, saveServerConfig, startServer, stopServer } from '../wails'
 
 const serverRunning = ref(false)
 const serverLog = ref<string[]>([])
@@ -88,12 +88,36 @@ watch(serverLog, async () => {
   if (logEl.value) logEl.value.scrollTop = logEl.value.scrollHeight
 })
 
+// 配置实时保存（#13）：修改后 debounce 500ms 静默保存；后端拒绝非法值（如 0.0.0.0）由后端兜底
+let configLoaded = false
+let saveTimer: ReturnType<typeof setTimeout> | null = null
+watch(cfg, () => {
+  if (!configLoaded) return
+  if (saveTimer) clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => {
+    saveServerConfig({
+      host: cfg.host,
+      port: cfg.port,
+      maxModels: cfg.maxModels,
+      cacheRam: cfg.cacheRam,
+    }).catch((e) => {
+      serverLog.value.push('配置保存失败: ' + (e instanceof Error ? e.message : String(e)))
+    })
+  }, 500)
+})
+
+onUnmounted(() => { if (saveTimer) clearTimeout(saveTimer) })
+
 onMounted(async () => {
   // Load server config
   try {
     const scfg = await getServerConfig()
     Object.assign(cfg, scfg)
   } catch {}
+  // 初始配置加载触发的 watch 回调会在下一次 flush 中执行（此时 configLoaded 仍为 false，
+  // 直接跳过保存），await nextTick() 等待该次 flush 完成后才启用自动保存，避免加载即保存。
+  await nextTick()
+  configLoaded = true
 
   // Load available models
   try {
@@ -121,14 +145,13 @@ async function toggleServer() {
     if (serverRunning.value) {
       await stopServer()
     } else {
+      await refreshModels() // 启动前强制重扫模型，确保预设基于最新模型列表（#18）
       await startServer()
     }
-    serverRunning.value = !serverRunning.value
-    if (!serverRunning.value) serverLog.value = []
-  } catch (e: any) {
-    serverLog.value.push('无法连接后端: ' + e.message)
+  } catch (e) {
+    serverLog.value.push('启动/停止服务失败: ' + (e instanceof Error ? e.message : String(e)))
   }
-  // Refresh status
+  // 状态统一由 checkServerStatus 延迟刷新真实值，不做乐观翻转（#14）
   setTimeout(checkServerStatus, 500)
 }
 </script>

--- a/frontend/src/views/Downloads.vue
+++ b/frontend/src/views/Downloads.vue
@@ -24,6 +24,7 @@
           :key="f.value"
           class="filter-btn"
           :class="{ active: activeFilter === f.value }"
+          :disabled="searching"
           @click="activeFilter = f.value; doSearch()"
         >{{ f.label }}</button>
       </div>
@@ -153,8 +154,10 @@
 import { ref, reactive, onMounted, onUnmounted } from 'vue'
 import {
   searchDownloads, getModelFiles, startDownload as startHFDownload, getDownloadTasks,
-  cancelDownloadTask, pauseDownloadTask, resumeDownloadTask
+  cancelDownloadTask, pauseDownloadTask, resumeDownloadTask, refreshModels
 } from '../wails'
+import { LatestOnly } from '../lib/latestOnly'
+import { hasActiveTask } from '../lib/taskStatus'
 
 interface HFResult {
   modelId: string
@@ -194,6 +197,7 @@ const selectedFiles = reactive<Record<string, string[]>>({})
 
 const tasks = ref<DlTask[]>([])
 let taskPollTimer: ReturnType<typeof setInterval> | null = null
+let lastDoneCount = 0
 
 const filters = [
   { label: '嵌入模型', value: 'embedding' },
@@ -247,15 +251,18 @@ function guessQuant(filename: string): string {
   return ''
 }
 
+const searchGate = new LatestOnly()
 async function doSearch() {
   if (!searchQuery.value) return
+  const seq = searchGate.begin()
   searching.value = true
   searched.value = true
   try {
     const results = await searchDownloads(searchQuery.value, activeFilter.value)
+    if (!searchGate.isLatest(seq)) return  // 过期结果丢弃（#15）
     searchResults.value = results || []
   } catch {} finally {
-    searching.value = false
+    if (searchGate.isLatest(seq)) searching.value = false
   }
 }
 
@@ -300,35 +307,55 @@ async function startDownload(modelId: string) {
   try {
     await startHFDownload(modelId, sel)
     expandedModel.value = ''
-    fetchTasks()
+    ensurePolling()
   } catch {}
 }
 
 async function fetchTasks() {
   try {
     tasks.value = await getDownloadTasks() || []
+    // 检测到新增完成任务时强制重扫模型列表（#18）
+    const doneCount = tasks.value.filter(t => t.status === 'done').length
+    if (doneCount > lastDoneCount) {
+      lastDoneCount = doneCount
+      refreshModels().catch(() => {})
+    }
+    // 全部任务进入终态后停止轮询（#16）
+    if (!hasActiveTask(tasks.value) && taskPollTimer) {
+      clearInterval(taskPollTimer)
+      taskPollTimer = null
+    }
   } catch {}
 }
 
 async function cancelTask(id: string) {
   try {
     await cancelDownloadTask(id)
-    fetchTasks()
+    ensurePolling()
   } catch {}
 }
 
 async function pauseTask(id: string) {
   try {
     await pauseDownloadTask(id)
-    fetchTasks()
+    ensurePolling()
   } catch {}
 }
 
 async function resumeTask(id: string) {
   try {
     await resumeDownloadTask(id)
-    fetchTasks()
+    ensurePolling()
   } catch {}
+}
+
+/** 启动新下载或手动操作后：轮询已停止则重启，否则立即刷新一次（#16） */
+function ensurePolling() {
+  if (taskPollTimer) {
+    fetchTasks()
+  } else {
+    startTaskPolling()
+  }
 }
 
 function startTaskPolling() {

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -27,7 +27,7 @@
     </div>
 
     <!-- Data -->
-    <template v-else-if="!error || info.cpu.model">
+    <template v-else>
       <!-- CPU Card -->
       <section class="info-section">
         <h2 class="section-title">

--- a/frontend/src/views/Models.vue
+++ b/frontend/src/views/Models.vue
@@ -1,11 +1,14 @@
 <template>
   <div class="page">
     <div class="page-header">
-      <h1 class="page-title">模型</h1>
-      <p class="page-subtitle">
-        <template v-if="models.length">{{ models.length }} 个模型</template>
-        <template v-else>将 GGUF 模型文件放入 LLM-Models 目录</template>
-      </p>
+      <div class="page-header-text">
+        <h1 class="page-title">模型</h1>
+        <p class="page-subtitle">
+          <template v-if="models.length">{{ models.length }} 个模型</template>
+          <template v-else>将 GGUF 模型文件放入 LLM-Models 目录</template>
+        </p>
+      </div>
+      <button class="refresh-btn" :disabled="loading" title="重新扫描 LLM-Models 目录" @click="fetchModels(true)">刷新</button>
     </div>
 
     <!-- Loading skeleton -->
@@ -26,7 +29,7 @@
       </div>
       <h2>无法获取模型列表</h2>
       <p>{{ error }}</p>
-      <button class="retry-btn" @click="fetchModels">重试</button>
+      <button class="retry-btn" @click="fetchModels()">重试</button>
     </div>
 
     <!-- Empty state -->
@@ -92,7 +95,7 @@
 import { ref, onMounted } from 'vue'
 import ModelSettings from '../components/ModelSettings.vue'
 import type { ModelConfig } from '../components/ModelSettings.vue'
-import { getModels, getModelConfig, saveModelConfig } from '../wails'
+import { getModels, getModelConfig, saveModelConfig, refreshModels } from '../wails'
 
 interface ModelInfo {
   author: string
@@ -151,13 +154,14 @@ async function saveSettings(config: ModelConfig) {
   }
 }
 
-async function fetchModels() {
+async function fetchModels(force = false) {
   loading.value = true
   error.value = ''
   try {
-    models.value = await getModels() as ModelInfo[]
-  } catch (e: any) {
-    error.value = `无法连接后端服务：${e.message}`
+    // force=true 时强制重扫 LLM-Models（refreshModels），否则走缓存（getModels）（#18）
+    models.value = (force ? await refreshModels() : await getModels()) as ModelInfo[]
+  } catch (e) {
+    error.value = `无法连接后端服务：${e instanceof Error ? e.message : String(e)}`
   } finally {
     loading.value = false
   }
@@ -173,7 +177,39 @@ onMounted(fetchModels)
 }
 
 .page-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
   margin-bottom: 36px;
+}
+
+.page-header-text {
+  min-width: 0;
+}
+
+.refresh-btn {
+  padding: 8px 18px;
+  background: rgba(99, 102, 241, 0.15);
+  color: #a78bfa;
+  border: 1px solid rgba(99, 102, 241, 0.25);
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background: rgba(99, 102, 241, 0.25);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.refresh-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
 }
 
 .page-title {


### PR DESCRIPTION
## 背景

前端交互审计（Tracker #12）发现的 8 项缺陷（P1×1、P2×5、P3×2）全部修复。

## 修复内容

- #13 API 页服务器配置实时保存（debounce 500ms，防初始加载误保存）
- #14 toggleServer 错误信息透传真实业务错误 + 去除乐观翻转
- #15 Downloads 搜索竞态保护（LatestOnly 序号门控 + 筛选按钮 disabled）
- #16 下载任务轮询全部终态即停 + ensurePolling 按需重启
- #18 refreshModels 接入：Downloads done 检测 / Models 刷新按钮 / Api 启动前重扫
- #17 ModelSettings 弹窗 a11y：Esc 关闭、role=dialog、aria-modal、aria-labelledby、Tab 焦点陷阱、打开自动聚焦
- #19 数值输入 min/max/step 约束 + Home.vue 条件链简化

## 测试

新增纯逻辑模块 `frontend/src/lib/`（LatestOnly、hasActiveTask）+ vitest 聚焦测试（7 例），遵循「不 mock 纯函数」规范。a11y DOM 交互（焦点陷阱/Esc）无法用 vitest 单测（无 @vue/test-utils 且未新增依赖），核心逻辑已抽纯函数覆盖。

## 验证

- cd frontend && npm run build PASS（vue-tsc 零错误）
- cd frontend && npm test PASS（3 files / 11 tests）

Fixes #12
Fixes #13
Fixes #14
Fixes #15
Fixes #16
Fixes #17
Fixes #18
Fixes #19